### PR TITLE
fix: use `prepare` over `postinstall` for husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node": ">=v14.21.3"
   },
   "scripts": {
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "start": "microbundle watch",


### PR DESCRIPTION
Fixes #275 

See: https://github.com/typicode/husky/issues/884

