### PR TITLE
fix: reacquire wake lock check after release

### DIFF
--- a/src/use-wake-lock.ts
+++ b/src/use-wake-lock.ts
@@ -75,7 +75,7 @@ export const useWakeLock = ({
       const handleVisibilityChange = async () => {
         if (wakeLock.current === null && document.visibilityState === 'visible') {
           try {
-            wakeLock.current = await navigator.wakeLock.request('screen');
+            await request();
           } catch (error: any) {
             onError?.(error);
           }

--- a/src/use-wake-lock.ts
+++ b/src/use-wake-lock.ts
@@ -73,7 +73,7 @@ export const useWakeLock = ({
   React.useEffect(() => {
     if (reacquireOnPageVisible) {
       const handleVisibilityChange = async () => {
-        if (wakeLock.current && document.visibilityState === 'visible') {
+        if (wakeLock.current == null && document.visibilityState === 'visible') {
           try {
             wakeLock.current = await navigator.wakeLock.request('screen');
           } catch (error: any) {

--- a/src/use-wake-lock.ts
+++ b/src/use-wake-lock.ts
@@ -56,7 +56,7 @@ export const useWakeLock = ({
   );
 
   const release = React.useCallback(async () => {
-    const isWakeLockUndefined = wakeLock.current == null;
+    const isWakeLockUndefined = wakeLock.current === null;
     if (!isSupported) {
       return warn(
         "Calling the `release` function has no effect, Wake Lock Screen API isn't supported"
@@ -73,7 +73,7 @@ export const useWakeLock = ({
   React.useEffect(() => {
     if (reacquireOnPageVisible) {
       const handleVisibilityChange = async () => {
-        if (wakeLock.current == null && document.visibilityState === 'visible') {
+        if (wakeLock.current === null && document.visibilityState === 'visible') {
           try {
             wakeLock.current = await navigator.wakeLock.request('screen');
           } catch (error: any) {

--- a/src/use-wake-lock.ts
+++ b/src/use-wake-lock.ts
@@ -88,7 +88,7 @@ export const useWakeLock = ({
       };
     }
     return undefined;
-  }, [reacquireOnPageVisible, onError]);
+  }, [reacquireOnPageVisible, request, onError]);
 
   return {
     isSupported,

--- a/test/use-wake-lock.test.tsx
+++ b/test/use-wake-lock.test.tsx
@@ -172,40 +172,6 @@ test('useWakeLock should call `onRelease` when wakeLockSentinel is released', as
   expect(handleRelease).toHaveBeenCalledWith(expect.any(Event));
 });
 
-test('useWakeLock reacquires wake lock on page visibility change when `reacquireOnPageVisible` is true', async () => {
-  const handleError = jest.fn();
-  const { result } = renderHook(() => useWakeLock({ reacquireOnPageVisible: true, onError: handleError }));
-
-  await act(async () => {
-    await result.current.request();
-  });
-
-  expect(window.navigator.wakeLock.request).toHaveBeenCalledTimes(1);
-  expect(result.current.type).toEqual('screen');
-  expect(result.current.released).toBe(false);
-
-  // Mock document.visibilityState to 'hidden'
-  Object.defineProperty(document, 'visibilityState', {
-    value: 'hidden',
-    configurable: true,
-  });
-  document.dispatchEvent(new Event('visibilitychange'));
-
-  // Mock document.visibilityState to 'visible'
-  Object.defineProperty(document, 'visibilityState', {
-    value: 'visible',
-    configurable: true,
-  });
-  await act(async () => {
-    document.dispatchEvent(new Event('visibilitychange'));
-  });
-
-  expect(window.navigator.wakeLock.request).toHaveBeenCalledTimes(2);
-  expect(result.current.type).toEqual('screen');
-  expect(result.current.released).toBe(false);
-  expect(handleError).not.toHaveBeenCalled();
-});
-
 test('after releasing, useWakeLock reacquires wake lock on page visibility change when `reacquireOnPageVisible` is true', async () => {
   const handleError = jest.fn();
   const { result } = renderHook(() => useWakeLock({ reacquireOnPageVisible: true, onError: handleError }));


### PR DESCRIPTION
## Context

Follow-up to #279.

https://github.com/jorisre/react-screen-wake-lock/pull/279#discussion_r2044770829

<img width="854" alt="image" src="https://github.com/user-attachments/assets/5e80c4f8-9e93-4200-a4ff-dc3c30664b8b" />

## Approach

Check that `wakeLock.current === null` before attempting to reacquire the lock.

Instead of using the vanilla `await navigator.wakeLock.request('screen')`, use the already-defined `request()` method to reacquire the lock. This ensures the release state and onRelease handlers are updated/called properly.
